### PR TITLE
Prevent double submissions across forms

### DIFF
--- a/src/AddressList.tsx
+++ b/src/AddressList.tsx
@@ -77,9 +77,10 @@ const AddressListComponent = function AddressList({
     null
   );
   const [pifAmount, setPifAmount] = React.useState<string>("");
-  
+
   // Prevent double submissions
   const [submittingIndex, setSubmittingIndex] = React.useState<number | null>(null);
+  const submittingRef = React.useRef<number | null>(null);
   const [lastSubmission, setLastSubmission] = React.useState<{index: number, outcome: string, timestamp: number} | null>(null);
   
   // Arrangement form state
@@ -98,7 +99,7 @@ const AddressListComponent = function AddressList({
   // Debounced completion handler with duplicate protection
   const handleCompletion = React.useCallback(async (index: number, outcome: Outcome, amount?: string, arrangementId?: string) => {
     // Check if already submitting this index
-    if (submittingIndex === index) return;
+    if (submittingRef.current === index) return;
     
     // Check for duplicate submission within 2 seconds
     const now = Date.now();
@@ -110,6 +111,7 @@ const AddressListComponent = function AddressList({
     }
     
     try {
+      submittingRef.current = index;
       setSubmittingIndex(index);
       setLastSubmission({ index, outcome, timestamp: now });
       
@@ -119,9 +121,10 @@ const AddressListComponent = function AddressList({
       console.error('Completion failed:', error);
       // Could show user error here
     } finally {
+      submittingRef.current = null;
       setSubmittingIndex(null);
     }
-  }, [submittingIndex, lastSubmission, onComplete]);
+  }, [lastSubmission, onComplete]);
 
   if (visible.length === 0) {
     return (

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -17,7 +17,8 @@ export function Auth({ onSignIn, onSignUp, isLoading, error, onClearError }: Pro
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+    if (isLoading) return;
+
     if (!email || !password) {
       alert("Please enter email and password");
       return;

--- a/src/ImportExcel.tsx
+++ b/src/ImportExcel.tsx
@@ -12,10 +12,12 @@ export function ImportExcel({ onImported }: Props) {
   const [loading, setLoading] = React.useState(false);
   const [dragActive, setDragActive] = React.useState(false);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const loadingRef = React.useRef(false);
 
   const processFile = async (file: File) => {
-    if (!file) return;
-    
+    if (!file || loadingRef.current) return;
+
+    loadingRef.current = true;
     setLoading(true);
     try {
       const data = await file.arrayBuffer();
@@ -90,6 +92,7 @@ export function ImportExcel({ onImported }: Props) {
       console.error(err);
       alert("❌ Failed to read Excel file. Please ensure it's a valid .xlsx or .xls file.");
     } finally {
+      loadingRef.current = false;
       setLoading(false);
       // Clear file input
       if (fileInputRef.current) {
@@ -99,6 +102,7 @@ export function ImportExcel({ onImported }: Props) {
   };
 
   const onFile: React.ChangeEventHandler<HTMLInputElement> = async (e) => {
+    if (loadingRef.current) return;
     const file = e.target.files?.[0];
     if (file) {
       await processFile(file);
@@ -119,11 +123,12 @@ export function ImportExcel({ onImported }: Props) {
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (loadingRef.current) return;
     setDragActive(false);
 
     const files = Array.from(e.dataTransfer.files);
-    const excelFile = files.find(file => 
-      file.name.endsWith('.xlsx') || 
+    const excelFile = files.find(file =>
+      file.name.endsWith('.xlsx') ||
       file.name.endsWith('.xls') ||
       file.type.includes('spreadsheet')
     );

--- a/src/ManualAddressFAB.tsx
+++ b/src/ManualAddressFAB.tsx
@@ -15,6 +15,7 @@ export default function ManualAddressFAB({ onAdd, inline }: Props) {
   const [lat, setLat] = React.useState<string>("");
   const [lng, setLng] = React.useState<string>("");
   const [busy, setBusy] = React.useState(false);
+  const busyRef = React.useRef(false);
   const [err, setErr] = React.useState<string | null>(null);
 
   const reset = () => {
@@ -26,6 +27,7 @@ export default function ManualAddressFAB({ onAdd, inline }: Props) {
 
   const submit = async (e?: React.FormEvent) => {
     e?.preventDefault();
+    if (busyRef.current) return;
     setErr(null);
 
     const trimmed = address.trim();
@@ -45,6 +47,7 @@ export default function ManualAddressFAB({ onAdd, inline }: Props) {
       lngNum = v;
     }
 
+    busyRef.current = true;
     setBusy(true);
     try {
       await onAdd({ address: trimmed, lat: latNum, lng: lngNum } as AddressRow);
@@ -53,6 +56,7 @@ export default function ManualAddressFAB({ onAdd, inline }: Props) {
     } catch (e: any) {
       setErr(e?.message || String(e));
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
   };

--- a/src/components/FullScreenArrangementForm.tsx
+++ b/src/components/FullScreenArrangementForm.tsx
@@ -68,6 +68,7 @@ export default function FullScreenArrangementForm({
 
   const handleSubmit = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
+    if (isLoading) return;
     if (!validateAmount(formData.amount)) {
       amountInputRef.current?.focus();
       return;


### PR DESCRIPTION
## Summary
- Guard Auth form submission when already processing
- Add ref-based locks for address and arrangement submissions
- Serialize Excel imports to avoid concurrent processing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c3cf8f014483328d13b6f283101fcf