### PR TITLE
Improve address search region focus and postcode support

### DIFF
--- a/CENTRALIZED_ROUTING_SETUP.md
+++ b/CENTRALIZED_ROUTING_SETUP.md
@@ -114,6 +114,7 @@ SELECT * FROM get_api_usage_stats();
 - Real-time address autocomplete
 - Returns up to 10 suggestions per query
 - Optimized for UK addresses
+- Optional `focusLat` & `focusLon` parameters bias results toward a region
 
 ## Rate Limiting & Costs
 

--- a/src/services/centralizedRouting.ts
+++ b/src/services/centralizedRouting.ts
@@ -106,11 +106,14 @@ export async function geocodeAddresses(
 /**
  * Search for addresses with autocomplete
  * No API key required - handled server-side
+ * Optional focusLat/focusLon bias results toward a region
  */
 export async function searchAddresses(
   query: string,
   countryCode = "GB",
-  limit = 5
+  limit = 5,
+  focusLat?: number,
+  focusLon?: number,
 ): Promise<AddressAutocompleteResult[]> {
   if (!supabase) {
     console.error('Supabase client not available for address search');
@@ -126,7 +129,8 @@ export async function searchAddresses(
       body: {
         query: query.trim(),
         countryCode,
-        limit: Math.min(limit, 10)
+        limit: Math.min(limit, 10),
+        ...(focusLat !== undefined && focusLon !== undefined ? { focusLat, focusLon } : {})
       }
     });
 

--- a/supabase/functions/search-addresses/index.ts
+++ b/supabase/functions/search-addresses/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { sanitizeLimit } from './utils.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -10,6 +11,8 @@ interface AddressSearchRequest {
   query: string;
   countryCode?: string;
   limit?: number;
+  focusLat?: number;
+  focusLon?: number;
 }
 
 interface AddressSearchResult {
@@ -74,17 +77,26 @@ serve(async (req) => {
 
     // Parse request - handle both GET and POST
     let query: string, countryCode: string, limit: number
+    let focusLat: number | undefined, focusLon: number | undefined
 
     if (req.method === 'GET') {
       const url = new URL(req.url)
       query = url.searchParams.get('query') || ''
       countryCode = url.searchParams.get('countryCode') || 'GB'
-      limit = parseInt(url.searchParams.get('limit') || '5')
+      limit = sanitizeLimit(url.searchParams.get('limit'))
+      const latParam = Number(url.searchParams.get('focusLat'))
+      focusLat = Number.isFinite(latParam) ? latParam : undefined
+      const lonParam = Number(url.searchParams.get('focusLon'))
+      focusLon = Number.isFinite(lonParam) ? lonParam : undefined
     } else {
       const body: AddressSearchRequest = await req.json()
       query = body.query
       countryCode = body.countryCode || 'GB'
-      limit = body.limit || 5
+      limit = sanitizeLimit(body.limit)
+      const latParam = Number(body.focusLat)
+      focusLat = Number.isFinite(latParam) ? latParam : undefined
+      const lonParam = Number(body.focusLon)
+      focusLon = Number.isFinite(lonParam) ? lonParam : undefined
     }
 
     if (!query.trim() || query.length < 3) {
@@ -140,40 +152,45 @@ serve(async (req) => {
     if (hasPostcode && countryCode === 'GB') {
       const postcodeMatch = query.match(/([A-Z]{1,2}[0-9]{1,2}\s?[0-9][A-Z]{2})/i)
       const addressPart = query.replace(/[A-Z]{1,2}[0-9]{1,2}\s?[0-9][A-Z]{2}/i, '').trim()
-      
-      if (postcodeMatch && addressPart) {
-        const searchStrategies = []
-        
-        // Strategy 2A: Structured search "address, postcode"
-        searchStrategies.push({
-          name: 'structured',
-          params: {
-            api_key: ORS_API_KEY,
-            text: `${addressPart}, ${postcodeMatch[1]}`,
-            'boundary.country': countryCode,
-            size: Math.min(limit, 10).toString(),
-            layers: 'address,venue',
-            'focus.point.lat': '51.5074',
-            'focus.point.lon': '-0.1278',
-          }
-        })
-        
-        // Strategy 2B: Just the street name + postcode (for interpolation)
-        const streetName = addressPart.replace(/^\d+\s*/, '').trim() // Remove house number
-        if (streetName !== addressPart && streetName.length > 3) {
+
+      if (postcodeMatch) {
+        const searchStrategies: any[] = []
+
+        if (addressPart) {
+          // Strategy 2A: Structured search "address, postcode"
+          const focusParams = (focusLat !== undefined && focusLon !== undefined)
+            ? { 'focus.point.lat': focusLat.toString(), 'focus.point.lon': focusLon.toString() }
+            : { 'focus.point.lat': '51.5074', 'focus.point.lon': '-0.1278' }
+
           searchStrategies.push({
-            name: 'street_postcode',
+            name: 'structured',
             params: {
               api_key: ORS_API_KEY,
-              text: `${streetName}, ${postcodeMatch[1]}`,
+              text: `${addressPart}, ${postcodeMatch[1]}`,
               'boundary.country': countryCode,
-              size: '5',
-              layers: 'street,address',
+              size: Math.min(limit, 10).toString(),
+              layers: 'address,venue',
+              ...focusParams,
             }
           })
+
+          // Strategy 2B: Just the street name + postcode (for interpolation)
+          const streetName = addressPart.replace(/^\d+\s*/, '').trim() // Remove house number
+          if (streetName !== addressPart && streetName.length > 3) {
+            searchStrategies.push({
+              name: 'street_postcode',
+              params: {
+                api_key: ORS_API_KEY,
+                text: `${streetName}, ${postcodeMatch[1]}`,
+                'boundary.country': countryCode,
+                size: '5',
+                layers: 'street,address',
+              }
+            })
+          }
         }
-        
-        // Strategy 2C: Just the postcode for area context
+
+        // Strategy 2C: Just the postcode for area context (works for postcode-only queries like "SW1 1AA")
         if (!hasGoodResults) {
           searchStrategies.push({
             name: 'postcode_only',
@@ -190,16 +207,16 @@ serve(async (req) => {
         // Execute fallback strategies
         for (const strategy of searchStrategies) {
           console.log(`Trying ${strategy.name} search: ${strategy.params.text}`)
-          
+
           const fallbackResponse = await fetch(`${searchUrl}?${new URLSearchParams(strategy.params)}`)
-          
+
           if (fallbackResponse.ok) {
             const fallbackData = await fallbackResponse.json()
-            
+
             if (fallbackData.features) {
               const fallbackResults = fallbackData.features.map((feature: any) => {
                 let confidence = feature.properties.confidence || 0.4
-                
+
                 // Boost confidence based on strategy
                 switch (strategy.name) {
                   case 'structured':
@@ -220,17 +237,17 @@ serve(async (req) => {
                     }
                     break
                 }
-                
+
                 return {
                   label: feature.properties.label,
                   coordinates: feature.geometry.coordinates,
                   confidence
                 }
               })
-              
+
               // Add fallback results, avoiding duplicates
               fallbackResults.forEach(newResult => {
-                const isDuplicate = searchResults.some(existing => 
+                const isDuplicate = searchResults.some(existing =>
                   Math.abs(existing.coordinates[0] - newResult.coordinates[0]) < 0.001 &&
                   Math.abs(existing.coordinates[1] - newResult.coordinates[1]) < 0.001
                 )
@@ -240,7 +257,7 @@ serve(async (req) => {
               })
             }
           }
-          
+
           // If we got good results from this strategy, stop trying more fallbacks
           const currentBest = Math.max(...searchResults.map(r => r.confidence || 0))
           if (currentBest > 0.8) {

--- a/supabase/functions/search-addresses/utils.test.ts
+++ b/supabase/functions/search-addresses/utils.test.ts
@@ -1,0 +1,21 @@
+import { sanitizeLimit } from "./utils.ts"
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected} but got ${actual}`)
+  }
+}
+
+Deno.test('sanitizeLimit falls back for invalid numbers', () => {
+  assertEquals(sanitizeLimit('abc'), 5)
+  assertEquals(sanitizeLimit(-1), 5)
+})
+
+Deno.test('sanitizeLimit accepts valid numbers', () => {
+  assertEquals(sanitizeLimit(3), 3)
+})
+
+Deno.test('postcode-only queries are detected', () => {
+  const hasPostcode = /[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}/i.test('SW1 1AA')
+  assertEquals(hasPostcode, true)
+})

--- a/supabase/functions/search-addresses/utils.ts
+++ b/supabase/functions/search-addresses/utils.ts
@@ -1,0 +1,4 @@
+export function sanitizeLimit(value: unknown, fallback = 5): number {
+  const num = Number(value)
+  return Number.isFinite(num) && num >= 1 ? num : fallback
+}


### PR DESCRIPTION
## Summary
- allow optional `focusLat`/`focusLon` to bias structured UK address searches
- support postcode-only lookups and sanitize `limit` parameter
- document new parameters and add basic Deno tests

## Testing
- `deno test supabase/functions/search-addresses/utils.test.ts`
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c72030731c8332b8a2d8e6b3e83804