### PR TITLE
Add name attributes to form fields

### DIFF
--- a/src/AdminDashboard.tsx
+++ b/src/AdminDashboard.tsx
@@ -346,8 +346,9 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
             <h3>Admin Actions</h3>
             <div className="admin-form">
               <div className="form-row">
-                <select 
-                  value={selectedUserId} 
+                <select
+                  name="selectedUserId"
+                  value={selectedUserId}
                   onChange={(e) => setSelectedUserId(e.target.value)}
                 >
                   <option value="">Select User...</option>
@@ -363,10 +364,11 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
                 <div className="action-group">
                   <div className="input-group">
                     <label>Grant Subscription (months):</label>
-                    <input 
-                      type="number" 
-                      min="1" 
-                      max="12" 
+                    <input
+                      name="grantMonths"
+                      type="number"
+                      min="1"
+                      max="12"
                       value={grantMonths}
                       onChange={(e) => setGrantMonths(parseInt(e.target.value) || 1)}
                     />
@@ -382,10 +384,11 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
                 <div className="action-group">
                   <div className="input-group">
                     <label>Extend Trial (days):</label>
-                    <input 
-                      type="number" 
-                      min="1" 
-                      max="90" 
+                    <input
+                      name="extendDays"
+                      type="number"
+                      min="1"
+                      max="90"
                       value={extendDays}
                       onChange={(e) => setExtendDays(parseInt(e.target.value) || 7)}
                     />
@@ -400,7 +403,8 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
               </div>
 
               <div className="form-row">
-                <textarea 
+                <textarea
+                  name="adminNotes"
                   placeholder="Admin notes (optional)"
                   value={adminNotes}
                   onChange={(e) => setAdminNotes(e.target.value)}

--- a/src/Arrangements.tsx
+++ b/src/Arrangements.tsx
@@ -987,7 +987,8 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
                   ⚠️ No addresses in your list. Switch to "Enter Manually" to add a new address.
                 </div>
               ) : (
-                <select 
+                <select
+                  name="addressIndex"
                   value={formData.addressIndex}
                   onChange={(e) => setFormData(prev => ({ ...prev, addressIndex: parseInt(e.target.value) }))}
                   className="input"
@@ -1096,9 +1097,10 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           <div className="form-group form-group-full">
             <label>🔄 Payment Schedule</label>
             <select
+              name="recurrenceType"
               value={formData.recurrenceType}
-              onChange={(e) => setFormData(prev => ({ 
-                ...prev, 
+              onChange={(e) => setFormData(prev => ({
+                ...prev,
                 recurrenceType: e.target.value as RecurrenceType,
                 recurrenceInterval: 1,
                 totalPayments: undefined
@@ -1140,6 +1142,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
             <div className="form-group">
               <label>📅 Interval</label>
               <select
+                name="recurrenceInterval"
                 value={formData.recurrenceInterval}
                 onChange={(e) => setFormData(prev => ({ ...prev, recurrenceInterval: parseInt(e.target.value) }))}
                 className="input"
@@ -1155,6 +1158,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           <div className="form-group form-group-full">
             <label>📝 Notes</label>
             <textarea
+              name="notes"
               value={formData.notes}
               onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
               className="input"

--- a/src/Completed.tsx
+++ b/src/Completed.tsx
@@ -461,6 +461,7 @@ export default function Completed({ state, onChangeOutcome }: Props) {
                                         <>
                                           <span>· £</span>
                                           <input
+                                            name="pifAmount"
                                             type="number"
                                             step="0.01"
                                             min="0"
@@ -572,6 +573,7 @@ export default function Completed({ state, onChangeOutcome }: Props) {
                               </div>
                               <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                                 <select
+                                  name={`outcome-${compIndex}`}
                                   value={(currentOutcome as string) || ""}
                                   onChange={(e) => onChangeOutcome(compIndex, e.target.value as Outcome, comp.amount)}
                                   className="input"

--- a/src/RoutePlanning.tsx
+++ b/src/RoutePlanning.tsx
@@ -523,12 +523,13 @@ export function RoutePlanning({ user, onAddressesReady }: RoutePlanningProps) {
                   
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <input
+                      name={`address-${index}`}
                       type="text"
                       value={addr.address}
                       onChange={(e) => handleEditAddress(index, e.target.value)}
                       className="input"
-                      style={{ 
-                        width: '100%', 
+                      style={{
+                        width: '100%',
                         marginBottom: '0.25rem',
                         fontSize: '0.875rem'
                       }}

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -175,6 +175,7 @@ export function AddressAutocomplete({
       <div style={{ position: 'relative' }}>
         <input
           ref={inputRef}
+          name="address"
           type="text"
           value={value}
           onChange={handleInputChange}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,6 +236,7 @@ export function PromptModal({
         <div className="prompt-modal">
           <div className="prompt-message">{message}</div>
           <input
+            name="modalInput"
             type={inputType}
             value={value}
             onChange={(e) => setValue(e.target.value)}

--- a/src/components/ReminderSettings.tsx
+++ b/src/components/ReminderSettings.tsx
@@ -199,6 +199,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label>👤 Agent Name *</label>
                   <input
+                    name="agentName"
                     type="text"
                     value={localSettings.agentProfile.name}
                     onChange={(e) => handleProfileUpdate({ name: e.target.value })}
@@ -211,6 +212,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label>🏷️ Job Title *</label>
                   <select
+                    name="agentTitle"
                     value={localSettings.agentProfile.title}
                     onChange={(e) => handleProfileUpdate({ title: e.target.value })}
                     className="input"
@@ -227,6 +229,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group form-group-full">
                   <label>✍️ Message Signature *</label>
                   <input
+                    name="agentSignature"
                     type="text"
                     value={localSettings.agentProfile.signature}
                     onChange={(e) => handleProfileUpdate({ signature: e.target.value })}
@@ -242,6 +245,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group form-group-full">
                   <label>📞 Contact Information (Optional)</label>
                   <input
+                    name="agentContactInfo"
                     type="text"
                     value={localSettings.agentProfile.contactInfo || ''}
                     onChange={(e) => handleProfileUpdate({ contactInfo: e.target.value })}
@@ -274,6 +278,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               <div className="form-group">
                 <label>Active Template</label>
                 <select
+                  name="activeTemplate"
                   value={localSettings.activeTemplateId}
                   onChange={(e) => setLocalSettings(prev => ({ ...prev, activeTemplateId: e.target.value }))}
                   className="input"
@@ -325,6 +330,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                         <div className="form-group">
                           <label>Template Name</label>
                           <input
+                            name={`templateName-${template.id}`}
                             type="text"
                             value={template.name}
                             onChange={(e) => handleTemplateUpdate(template.id, { name: e.target.value })}
@@ -334,6 +340,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                         <div className="form-group">
                           <label>Message Template</label>
                           <textarea
+                            name={`templateContent-${template.id}`}
                             value={template.template}
                             onChange={(e) => handleTemplateUpdate(template.id, { template: e.target.value })}
                             className="input"
@@ -363,6 +370,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               <div className="form-group">
                 <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <input
+                    name="globalEnabled"
                     type="checkbox"
                     checked={localSettings.globalEnabled}
                     onChange={(e) => setLocalSettings(prev => ({ ...prev, globalEnabled: e.target.checked }))}
@@ -374,6 +382,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               <div className="form-group">
                 <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <input
+                    name="smsEnabled"
                     type="checkbox"
                     checked={localSettings.smsEnabled}
                     onChange={(e) => setLocalSettings(prev => ({ ...prev, smsEnabled: e.target.checked }))}
@@ -390,6 +399,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="threeDayReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.threeDayReminder}
                       onChange={(e) => handleScheduleUpdate('threeDayReminder', e.target.checked)}
@@ -402,6 +412,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="oneDayReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.oneDayReminder}
                       onChange={(e) => handleScheduleUpdate('oneDayReminder', e.target.checked)}
@@ -414,6 +425,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="dayOfReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.dayOfReminder}
                       onChange={(e) => handleScheduleUpdate('dayOfReminder', e.target.checked)}
@@ -462,6 +474,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 
                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                   <input
+                    name="customDayInput"
                     type="number"
                     min="1"
                     max="365"


### PR DESCRIPTION
## Summary
- add `name` attributes to arrangement selectors and notes textarea
- label dashboard controls for selected user and subscription actions
- ensure all remaining form inputs, modals, and reminder settings have identifiers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c811c03ca48332a64080b0faf4d98f