### PR TITLE
Add name attributes to form fields

### DIFF
--- a/src/AdminDashboard.tsx
+++ b/src/AdminDashboard.tsx
@@ -346,8 +346,11 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
             <h3>Admin Actions</h3>
             <div className="admin-form">
               <div className="form-row">
-                <select 
-                  value={selectedUserId} 
+                <label htmlFor="selected-user-id">Select User</label>
+                <select
+                  id="selected-user-id"
+                  name="selectedUserId"
+                  value={selectedUserId}
                   onChange={(e) => setSelectedUserId(e.target.value)}
                 >
                   <option value="">Select User...</option>
@@ -362,11 +365,13 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
               <div className="form-row">
                 <div className="action-group">
                   <div className="input-group">
-                    <label>Grant Subscription (months):</label>
-                    <input 
-                      type="number" 
-                      min="1" 
-                      max="12" 
+                    <label htmlFor="grant-months">Grant Subscription (months):</label>
+                    <input
+                      id="grant-months"
+                      name="grantMonths"
+                      type="number"
+                      min="1"
+                      max="12"
                       value={grantMonths}
                       onChange={(e) => setGrantMonths(parseInt(e.target.value) || 1)}
                     />
@@ -381,11 +386,13 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
 
                 <div className="action-group">
                   <div className="input-group">
-                    <label>Extend Trial (days):</label>
-                    <input 
-                      type="number" 
-                      min="1" 
-                      max="90" 
+                    <label htmlFor="extend-days">Extend Trial (days):</label>
+                    <input
+                      id="extend-days"
+                      name="extendDays"
+                      type="number"
+                      min="1"
+                      max="90"
                       value={extendDays}
                       onChange={(e) => setExtendDays(parseInt(e.target.value) || 7)}
                     />
@@ -400,7 +407,10 @@ export function AdminDashboard({ user, onClose }: AdminDashboardProps) {
               </div>
 
               <div className="form-row">
-                <textarea 
+                <label htmlFor="admin-notes">Admin notes (optional)</label>
+                <textarea
+                  id="admin-notes"
+                  name="adminNotes"
                   placeholder="Admin notes (optional)"
                   value={adminNotes}
                   onChange={(e) => setAdminNotes(e.target.value)}

--- a/src/Arrangements.tsx
+++ b/src/Arrangements.tsx
@@ -951,7 +951,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           {/* Address Mode Toggle */}
           {!arrangement && (
             <div className="form-group form-group-full">
-              <label>📍 Address Source</label>
+              <div>📍 Address Source</div>
               <div className="btn-group">
                 <button
                   type="button"
@@ -974,7 +974,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           {/* Address Selection */}
           {addressMode === "existing" ? (
             <div className="form-group form-group-full">
-              <label>📍 Address *</label>
+              <label htmlFor="address-index">📍 Address *</label>
               {state.addresses.length === 0 ? (
                 <div style={{ 
                   padding: "0.75rem", 
@@ -987,7 +987,9 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
                   ⚠️ No addresses in your list. Switch to "Enter Manually" to add a new address.
                 </div>
               ) : (
-                <select 
+                <select
+                  id="address-index"
+                  name="addressIndex"
                   value={formData.addressIndex}
                   onChange={(e) => setFormData(prev => ({ ...prev, addressIndex: parseInt(e.target.value) }))}
                   className="input"
@@ -1003,7 +1005,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
             </div>
           ) : (
             <div className="form-group form-group-full">
-              <label>📍 Address *</label>
+              <label htmlFor="manual-address">📍 Address *</label>
               <input
                 id="manual-address"
                 name="manualAddress"
@@ -1022,7 +1024,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           )}
 
           <div className="form-group">
-            <label>💰 Payment Amount *</label>
+            <label htmlFor="payment-amount">💰 Payment Amount *</label>
             <input
               id="payment-amount"
               name="paymentAmount"
@@ -1039,7 +1041,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group">
-            <label>👤 Customer Name</label>
+            <label htmlFor="customer-name">👤 Customer Name</label>
             <input
               id="customer-name"
               name="customerName"
@@ -1053,7 +1055,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group">
-            <label>📞 Phone Number</label>
+            <label htmlFor="phone-number">📞 Phone Number</label>
             <input
               id="phone-number"
               name="phoneNumber"
@@ -1067,7 +1069,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group">
-            <label>📅 Payment Due Date *</label>
+            <label htmlFor="scheduled-date">📅 Payment Due Date *</label>
             <input
               id="scheduled-date"
               name="scheduledDate"
@@ -1081,7 +1083,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group">
-            <label>🕐 Preferred Time</label>
+            <label htmlFor="scheduled-time">🕐 Preferred Time</label>
             <input
               id="scheduled-time"
               name="scheduledTime"
@@ -1094,11 +1096,13 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group form-group-full">
-            <label>🔄 Payment Schedule</label>
+            <label htmlFor="recurrence-type">🔄 Payment Schedule</label>
             <select
+              id="recurrence-type"
+              name="recurrenceType"
               value={formData.recurrenceType}
-              onChange={(e) => setFormData(prev => ({ 
-                ...prev, 
+              onChange={(e) => setFormData(prev => ({
+                ...prev,
                 recurrenceType: e.target.value as RecurrenceType,
                 recurrenceInterval: 1,
                 totalPayments: undefined
@@ -1112,7 +1116,7 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           </div>
 
           <div className="form-group">
-            <label>🔢 Total Payments *</label>
+            <label htmlFor="total-payments">🔢 Total Payments *</label>
             <input
               id="total-payments"
               name="totalPayments"
@@ -1138,8 +1142,10 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
 
           {formData.recurrenceType !== "none" && (
             <div className="form-group">
-              <label>📅 Interval</label>
+              <label htmlFor="recurrence-interval">📅 Interval</label>
               <select
+                id="recurrence-interval"
+                name="recurrenceInterval"
                 value={formData.recurrenceInterval}
                 onChange={(e) => setFormData(prev => ({ ...prev, recurrenceInterval: parseInt(e.target.value) }))}
                 className="input"
@@ -1153,8 +1159,10 @@ function ArrangementForm({ state, arrangement, preSelectedAddressIndex, onAddAdd
           )}
 
           <div className="form-group form-group-full">
-            <label>📝 Notes</label>
+            <label htmlFor="notes">📝 Notes</label>
             <textarea
+              id="notes"
+              name="notes"
               value={formData.notes}
               onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
               className="input"

--- a/src/Completed.tsx
+++ b/src/Completed.tsx
@@ -460,7 +460,25 @@ export default function Completed({ state, onChangeOutcome }: Props) {
                                       {editingPifAmount === compIndex ? (
                                         <>
                                           <span>· £</span>
+                                          <label
+                                            htmlFor={`pif-amount-${compIndex}`}
+                                            style={{
+                                              position: 'absolute',
+                                              width: 1,
+                                              height: 1,
+                                              padding: 0,
+                                              margin: -1,
+                                              overflow: 'hidden',
+                                              clip: 'rect(0,0,0,0)',
+                                              whiteSpace: 'nowrap',
+                                              border: 0
+                                            }}
+                                          >
+                                            PIF Amount
+                                          </label>
                                           <input
+                                            id={`pif-amount-${compIndex}`}
+                                            name="pifAmount"
                                             type="number"
                                             step="0.01"
                                             min="0"
@@ -571,7 +589,25 @@ export default function Completed({ state, onChangeOutcome }: Props) {
                                 </div>
                               </div>
                               <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                                <label
+                                  htmlFor={`outcome-${compIndex}`}
+                                  style={{
+                                    position: 'absolute',
+                                    width: 1,
+                                    height: 1,
+                                    padding: 0,
+                                    margin: -1,
+                                    overflow: 'hidden',
+                                    clip: 'rect(0,0,0,0)',
+                                    whiteSpace: 'nowrap',
+                                    border: 0
+                                  }}
+                                >
+                                  Outcome
+                                </label>
                                 <select
+                                  id={`outcome-${compIndex}`}
+                                  name={`outcome-${compIndex}`}
                                   value={(currentOutcome as string) || ""}
                                   onChange={(e) => onChangeOutcome(compIndex, e.target.value as Outcome, comp.amount)}
                                   className="input"

--- a/src/RoutePlanning.tsx
+++ b/src/RoutePlanning.tsx
@@ -269,10 +269,11 @@ export function RoutePlanning({ user, onAddressesReady }: RoutePlanningProps) {
           {/* Manual Address Entry with Autocomplete */}
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-end' }}>
             <div style={{ flex: 1 }}>
-              <label style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.875rem' }}>
+              <label htmlFor="manual-address-input" style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.875rem' }}>
                 Or add addresses manually:
               </label>
               <AddressAutocomplete
+                id="manual-address-input"
                 value={newAddress}
                 onChange={setNewAddress}
                 onSelect={handleSelectFromAutocomplete}
@@ -523,12 +524,13 @@ export function RoutePlanning({ user, onAddressesReady }: RoutePlanningProps) {
                   
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <input
+                      name={`address-${index}`}
                       type="text"
                       value={addr.address}
                       onChange={(e) => handleEditAddress(index, e.target.value)}
                       className="input"
-                      style={{ 
-                        width: '100%', 
+                      style={{
+                        width: '100%',
                         marginBottom: '0.25rem',
                         fontSize: '0.875rem'
                       }}

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -4,6 +4,7 @@ import { resolveSelectedPlace } from "../services/geocoding";
 import type { AddressAutocompleteResult } from "../services/hybridRouting";
 
 interface AddressAutocompleteProps {
+  id?: string;
   value: string;
   onChange: (value: string) => void;
   onSelect: (address: string, lat: number, lng: number) => void;
@@ -13,6 +14,7 @@ interface AddressAutocompleteProps {
 }
 
 export function AddressAutocomplete({
+  id,
   value,
   onChange,
   onSelect,
@@ -174,7 +176,9 @@ export function AddressAutocomplete({
     <div style={{ position: 'relative', width: '100%' }}>
       <div style={{ position: 'relative' }}>
         <input
+          id={id}
           ref={inputRef}
+          name="address"
           type="text"
           value={value}
           onChange={handleInputChange}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -236,6 +236,7 @@ export function PromptModal({
         <div className="prompt-modal">
           <div className="prompt-message">{message}</div>
           <input
+            name="modalInput"
             type={inputType}
             value={value}
             onChange={(e) => setValue(e.target.value)}

--- a/src/components/ReminderSettings.tsx
+++ b/src/components/ReminderSettings.tsx
@@ -197,8 +197,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               
               <div className="form-grid">
                 <div className="form-group">
-                  <label>👤 Agent Name *</label>
+                  <label htmlFor="agent-name">👤 Agent Name *</label>
                   <input
+                    id="agent-name"
+                    name="agentName"
                     type="text"
                     value={localSettings.agentProfile.name}
                     onChange={(e) => handleProfileUpdate({ name: e.target.value })}
@@ -207,10 +209,12 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                     required
                   />
                 </div>
-                
+
                 <div className="form-group">
-                  <label>🏷️ Job Title *</label>
+                  <label htmlFor="agent-title">🏷️ Job Title *</label>
                   <select
+                    id="agent-title"
+                    name="agentTitle"
                     value={localSettings.agentProfile.title}
                     onChange={(e) => handleProfileUpdate({ title: e.target.value })}
                     className="input"
@@ -225,8 +229,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 </div>
                 
                 <div className="form-group form-group-full">
-                  <label>✍️ Message Signature *</label>
+                  <label htmlFor="agent-signature">✍️ Message Signature *</label>
                   <input
+                    id="agent-signature"
+                    name="agentSignature"
                     type="text"
                     value={localSettings.agentProfile.signature}
                     onChange={(e) => handleProfileUpdate({ signature: e.target.value })}
@@ -240,8 +246,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 </div>
                 
                 <div className="form-group form-group-full">
-                  <label>📞 Contact Information (Optional)</label>
+                  <label htmlFor="agent-contact-info">📞 Contact Information (Optional)</label>
                   <input
+                    id="agent-contact-info"
+                    name="agentContactInfo"
                     type="text"
                     value={localSettings.agentProfile.contactInfo || ''}
                     onChange={(e) => handleProfileUpdate({ contactInfo: e.target.value })}
@@ -272,8 +280,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               </div>
               
               <div className="form-group">
-                <label>Active Template</label>
+                <label htmlFor="active-template">Active Template</label>
                 <select
+                  id="active-template"
+                  name="activeTemplate"
                   value={localSettings.activeTemplateId}
                   onChange={(e) => setLocalSettings(prev => ({ ...prev, activeTemplateId: e.target.value }))}
                   className="input"
@@ -323,8 +333,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                     {editingTemplate === template.id && (
                       <div className="template-editor">
                         <div className="form-group">
-                          <label>Template Name</label>
+                          <label htmlFor={`template-name-${template.id}`}>Template Name</label>
                           <input
+                            id={`template-name-${template.id}`}
+                            name={`templateName-${template.id}`}
                             type="text"
                             value={template.name}
                             onChange={(e) => handleTemplateUpdate(template.id, { name: e.target.value })}
@@ -332,8 +344,10 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                           />
                         </div>
                         <div className="form-group">
-                          <label>Message Template</label>
+                          <label htmlFor={`template-content-${template.id}`}>Message Template</label>
                           <textarea
+                            id={`template-content-${template.id}`}
+                            name={`templateContent-${template.id}`}
                             value={template.template}
                             onChange={(e) => handleTemplateUpdate(template.id, { template: e.target.value })}
                             className="input"
@@ -363,6 +377,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               <div className="form-group">
                 <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <input
+                    name="globalEnabled"
                     type="checkbox"
                     checked={localSettings.globalEnabled}
                     onChange={(e) => setLocalSettings(prev => ({ ...prev, globalEnabled: e.target.checked }))}
@@ -374,6 +389,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
               <div className="form-group">
                 <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <input
+                    name="smsEnabled"
                     type="checkbox"
                     checked={localSettings.smsEnabled}
                     onChange={(e) => setLocalSettings(prev => ({ ...prev, smsEnabled: e.target.checked }))}
@@ -390,6 +406,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="threeDayReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.threeDayReminder}
                       onChange={(e) => handleScheduleUpdate('threeDayReminder', e.target.checked)}
@@ -402,6 +419,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="oneDayReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.oneDayReminder}
                       onChange={(e) => handleScheduleUpdate('oneDayReminder', e.target.checked)}
@@ -414,6 +432,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 <div className="form-group">
                   <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                     <input
+                      name="dayOfReminder"
                       type="checkbox"
                       checked={localSettings.customizableSchedule.dayOfReminder}
                       onChange={(e) => handleScheduleUpdate('dayOfReminder', e.target.checked)}
@@ -462,6 +481,7 @@ export function ReminderSettings({ settings, onUpdateSettings, onClose }: Props)
                 
                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                   <input
+                    name="customDayInput"
                     type="number"
                     min="1"
                     max="365"


### PR DESCRIPTION
## Summary
- link admin dashboard controls and notes textarea to matching labels
- connect arrangement, route planning, and reminder settings fields with `label`/`id` pairs
- expose `id` prop for address autocomplete and add hidden labels for dynamic completion inputs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c811c03ca48332a64080b0faf4d98f