### PR TITLE
Preserve local completions when cloud updates arrive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ class ErrorBoundary extends React.Component<
 // Enhanced Upload JSON snapshot to Supabase Storage with retry mechanism
 async function uploadBackupToStorage(
   data: unknown,
-  label: "finish" | "manual" = "manual",
+  label: "finish" | "manual" | "periodic" = "manual",
   retryCount = 0
 ) {
   if (!supabase) {

--- a/src/components/BackupManager.tsx
+++ b/src/components/BackupManager.tsx
@@ -62,7 +62,7 @@ export function BackupManager({ currentData, onRestore, isOpen, onClose }: Backu
     }
   };
 
-  const downloadBackup = (backup: any, index: number) => {
+  const downloadBackup = (backup: any, _index: number) => {
     try {
       const timestamp = new Date(backup.timestamp).toISOString().replace(/[:.]/g, '-');
       LocalBackupManager.downloadBackup(backup.data, `navigator-backup-${timestamp}.json`);

--- a/src/components/SupabaseSetup.tsx
+++ b/src/components/SupabaseSetup.tsx
@@ -36,7 +36,7 @@ export function SupabaseSetup({ onSetupComplete, onSkip, isOpen }: SupabaseSetup
 
       // Test connection
       const testClient = createClient(url, key);
-      const { data, error } = await testClient.auth.getSession();
+      const { data: _data, error } = await testClient.auth.getSession();
 
       if (error && error.message !== 'Auth session missing!') {
         throw error;

--- a/src/useCloudSync.ts
+++ b/src/useCloudSync.ts
@@ -76,8 +76,147 @@ export function mergeStatePreservingActiveIndex(
   current: AppState,
   incoming: AppState
 ): AppState {
+  const currentListVersion =
+    typeof current.currentListVersion === "number"
+      ? current.currentListVersion
+      : 1;
+  const incomingListVersion =
+    typeof incoming.currentListVersion === "number"
+      ? incoming.currentListVersion
+      : 1;
+
+  const ensureListVersion = (listVersion?: number) =>
+    typeof listVersion === "number"
+      ? listVersion
+      : Math.max(currentListVersion, incomingListVersion);
+
+  const mergedCompletionMap = new Map<string, AppState["completions"][number]>();
+  const pushCompletion = (
+    completion: AppState["completions"][number] | undefined
+  ) => {
+    if (!completion) return;
+    if (
+      typeof completion.index !== "number" ||
+      typeof completion.timestamp !== "string" ||
+      !completion.outcome
+    ) {
+      return;
+    }
+
+    const normalized = {
+      ...completion,
+      listVersion: ensureListVersion(completion.listVersion),
+    };
+
+    const key = `${normalized.timestamp}_${normalized.index}_${normalized.outcome}`;
+    const existing = mergedCompletionMap.get(key);
+
+    if (!existing) {
+      mergedCompletionMap.set(key, normalized);
+      return;
+    }
+
+    // Merge extra fields (amount/arrangementId) while keeping most recent data
+    const existingTime = new Date(existing.timestamp).getTime();
+    const incomingTime = new Date(normalized.timestamp).getTime();
+
+    if (incomingTime > existingTime) {
+      mergedCompletionMap.set(key, {
+        ...existing,
+        ...normalized,
+      });
+      return;
+    }
+
+    mergedCompletionMap.set(key, {
+      ...normalized,
+      ...existing,
+    });
+  };
+
+  incoming.completions?.forEach(pushCompletion);
+  current.completions?.forEach(pushCompletion);
+
+  const mergedCompletions = Array.from(mergedCompletionMap.values()).sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  const selectAddresses = () => {
+    const currentAddresses = Array.isArray(current.addresses)
+      ? current.addresses
+      : [];
+    const incomingAddresses = Array.isArray(incoming.addresses)
+      ? incoming.addresses
+      : [];
+
+    return incomingAddresses.length >= currentAddresses.length
+      ? incomingAddresses
+      : currentAddresses;
+  };
+
+  const mergedArrangementsMap = new Map<string, AppState["arrangements"][number]>();
+  const pushArrangement = (
+    arrangement: AppState["arrangements"][number] | undefined
+  ) => {
+    if (!arrangement?.id) return;
+    const existing = mergedArrangementsMap.get(arrangement.id);
+    if (!existing) {
+      mergedArrangementsMap.set(arrangement.id, arrangement);
+      return;
+    }
+
+    const existingUpdated = new Date(existing.updatedAt).getTime();
+    const candidateUpdated = new Date(arrangement.updatedAt).getTime();
+    if (candidateUpdated > existingUpdated) {
+      mergedArrangementsMap.set(arrangement.id, arrangement);
+    }
+  };
+
+  current.arrangements?.forEach(pushArrangement);
+  incoming.arrangements?.forEach(pushArrangement);
+
+  const mergedDaySessionsMap = new Map<string, AppState["daySessions"][number]>();
+  const pushDaySession = (
+    session: AppState["daySessions"][number] | undefined
+  ) => {
+    if (!session?.date) return;
+    const existing = mergedDaySessionsMap.get(session.date);
+    if (!existing) {
+      mergedDaySessionsMap.set(session.date, session);
+      return;
+    }
+
+    const existingHasEnd = Boolean(existing.end);
+    const candidateHasEnd = Boolean(session.end);
+
+    if (!existingHasEnd && candidateHasEnd) {
+      mergedDaySessionsMap.set(session.date, session);
+      return;
+    }
+
+    if (existingHasEnd && candidateHasEnd) {
+      const existingEnd = new Date(existing.end ?? existing.start).getTime();
+      const candidateEnd = new Date(session.end ?? session.start).getTime();
+      if (candidateEnd > existingEnd) {
+        mergedDaySessionsMap.set(session.date, session);
+      }
+    }
+  };
+
+  current.daySessions?.forEach(pushDaySession);
+  incoming.daySessions?.forEach(pushDaySession);
+
+  const mergedDaySessions = Array.from(mergedDaySessionsMap.values());
+
+  const mergedArrangements = Array.from(mergedArrangementsMap.values());
+
   return {
     ...incoming,
+    addresses: selectAddresses(),
+    completions: mergedCompletions,
+    arrangements: mergedArrangements,
+    daySessions: mergedDaySessions,
+    currentListVersion: Math.max(currentListVersion, incomingListVersion),
     activeIndex: incoming.activeIndex ?? current.activeIndex ?? null,
   };
 }

--- a/src/utils/localBackup.ts
+++ b/src/utils/localBackup.ts
@@ -4,7 +4,6 @@ import { logger } from './logger';
 export class LocalBackupManager {
   private static readonly BACKUP_KEY = 'navigator_local_backups';
   private static readonly MAX_BACKUPS = 10;
-  private static readonly BACKUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
   // Download backup as file to user's Downloads folder
   static downloadBackup(data: any, filename?: string): void {


### PR DESCRIPTION
## Summary
- merge incoming cloud state with existing completions, arrangements, day sessions, and address lists so local work is not lost when stale updates arrive
- relax backup helper label typing and silence TypeScript warnings found during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca498e4b9883328b77285208488d56