### PR TITLE
Defensively clean up Google Maps temp div

### DIFF
--- a/src/services/googleMapsSDK.ts
+++ b/src/services/googleMapsSDK.ts
@@ -147,7 +147,9 @@ export async function getPlaceDetails(
     service.getDetails(request, (place: google.maps.places.PlaceResult | null, status: google.maps.places.PlacesServiceStatus) => {
       // Clean up temporary DOM element immediately
       try {
-        if (tempDiv.parentNode) {
+        if (tempDiv.isConnected) {
+          tempDiv.remove();
+        } else if (tempDiv.parentNode?.contains(tempDiv)) {
           tempDiv.parentNode.removeChild(tempDiv);
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- add a defensive cleanup check when removing the temporary div created for Google Places lookups
- avoid calling removeChild on a node that is no longer connected to the DOM

## Testing
- npm run build
- Unable to run the Route Planning flow in this environment because the Google Maps API key is not configured


------
https://chatgpt.com/codex/tasks/task_e_68ce722eb76483328ddc11fb8dcc78da