### PR TITLE
Handle Google Maps temp div cleanup safely

### DIFF
--- a/src/services/googleMapsSDK.ts
+++ b/src/services/googleMapsSDK.ts
@@ -154,8 +154,14 @@ export async function getPlaceDetails(
       }
       cleanupAttempted = true;
 
-      if (tempDiv.parentNode) {
-        tempDiv.parentNode.removeChild(tempDiv);
+      if (typeof tempDiv.remove === 'function') {
+        tempDiv.remove();
+        return;
+      }
+
+      const parent = tempDiv.parentNode as Node | null;
+      if (parent && parent instanceof Node && parent.contains(tempDiv)) {
+        parent.removeChild(tempDiv);
       }
     };
 


### PR DESCRIPTION
## Summary
- ensure the temporary PlacesService div uses `remove()` when available during cleanup
- fall back to removing the element from its parent only when it is still attached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea7c35a448332866275ba5c081a42