### PR TITLE
Improve temporary div cleanup for Google Maps place details

### DIFF
--- a/src/services/googleMapsSDK.ts
+++ b/src/services/googleMapsSDK.ts
@@ -159,9 +159,27 @@ export async function getPlaceDetails(
         return;
       }
 
-      const parent = tempDiv.parentNode as Node | null;
-      if (parent && parent instanceof Node && parent.contains(tempDiv)) {
+      const parent = tempDiv.parentNode;
+      if (!(parent instanceof Node)) {
+        return;
+      }
+
+      const shouldAttemptRemoval =
+        typeof (tempDiv as { isConnected?: boolean }).isConnected === 'boolean'
+          ? (tempDiv as { isConnected: boolean }).isConnected
+          : parent.contains(tempDiv);
+
+      if (!shouldAttemptRemoval && !parent.contains(tempDiv)) {
+        return;
+      }
+
+      try {
         parent.removeChild(tempDiv);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'NotFoundError') {
+          return;
+        }
+        console.debug('Temp div cleanup encountered an unexpected error:', error);
       }
     };
 


### PR DESCRIPTION
## Summary
- refine the temporary div fallback cleanup to verify the parent node and skip removal when already detached
- guard removal using isConnected/contains checks and swallow NotFoundError DOMExceptions while logging unexpected errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea9c254fc83328db0dee07d93233e