### PR TITLE
Refine temp div cleanup in Google Maps SDK

### DIFF
--- a/src/services/googleMapsSDK.ts
+++ b/src/services/googleMapsSDK.ts
@@ -164,12 +164,15 @@ export async function getPlaceDetails(
         return;
       }
 
-      const shouldAttemptRemoval =
-        typeof (tempDiv as { isConnected?: boolean }).isConnected === 'boolean'
-          ? (tempDiv as { isConnected: boolean }).isConnected
-          : parent.contains(tempDiv);
+      const { isConnected } = tempDiv as { isConnected?: boolean };
+      const isAttached =
+        typeof isConnected === 'boolean' ? isConnected : parent.contains(tempDiv);
 
-      if (!shouldAttemptRemoval && !parent.contains(tempDiv)) {
+      if (!isAttached) {
+        return;
+      }
+
+      if (!parent.contains(tempDiv)) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- derive a single attachment flag for the temporary PlacesService container using `isConnected` with a `contains` fallback
- add explicit guards before attempting removal to avoid errors when the node is no longer attached

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceab9a351483328f9b469a3b5ba74f