### PR TITLE
Adjust temp div cleanup to check attachment before removing

### DIFF
--- a/src/services/googleMapsSDK.ts
+++ b/src/services/googleMapsSDK.ts
@@ -154,21 +154,25 @@ export async function getPlaceDetails(
       }
       cleanupAttempted = true;
 
+      const parent = tempDiv.parentNode;
+      const { isConnected } = tempDiv as { isConnected?: boolean };
+      const isAttached =
+        typeof isConnected === 'boolean'
+          ? isConnected
+          : parent instanceof Node
+            ? parent.contains(tempDiv)
+            : false;
+
+      if (!isAttached) {
+        return;
+      }
+
       if (typeof tempDiv.remove === 'function') {
         tempDiv.remove();
         return;
       }
 
-      const parent = tempDiv.parentNode;
       if (!(parent instanceof Node)) {
-        return;
-      }
-
-      const { isConnected } = tempDiv as { isConnected?: boolean };
-      const isAttached =
-        typeof isConnected === 'boolean' ? isConnected : parent.contains(tempDiv);
-
-      if (!isAttached) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- precompute the temporary div's parent and attachment status before invoking any removal strategy
- skip cleanup when the temporary div is already detached while retaining the guarded fallback removal path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceae9793f88332a8881f04fa085129