### PR TITLE
Handle future sessions when sanitizing

### DIFF
--- a/src/useAppState.sessions.test.ts
+++ b/src/useAppState.sessions.test.ts
@@ -49,6 +49,31 @@ describe("prepareStartDaySessions", () => {
     expect(result.updatedSessions).toHaveLength(2);
     expect(result.updatedSessions[1]).toBe(todaySession);
   });
+
+  it("keeps future-dated sessions open when starting today", () => {
+    const today = "2024-03-10";
+    const now = new Date(`${today}T09:00:00.000Z`);
+    const tomorrow = "2024-03-11";
+
+    const futureSession: DaySession = {
+      date: tomorrow,
+      start: `${tomorrow}T08:00:00.000Z`,
+    };
+
+    const sessions: DaySession[] = [futureSession];
+
+    const result = prepareStartDaySessions(sessions, today, now);
+
+    expect(result.alreadyActive).toBe(false);
+    expect(result.closedSessions).toHaveLength(0);
+    expect(result.newSession).toBeDefined();
+    expect(result.updatedSessions).toHaveLength(2);
+    expect(result.updatedSessions[0]).toBe(futureSession);
+    expect(result.updatedSessions[0].end).toBeUndefined();
+    expect(result.updatedSessions[1]).toBe(result.newSession);
+    expect(result.newSession?.date).toBe(today);
+    expect(result.newSession?.start).toBe(now.toISOString());
+  });
 });
 
 describe("prepareEndDaySessions", () => {

--- a/src/useAppState.ts
+++ b/src/useAppState.ts
@@ -187,7 +187,7 @@ function sanitizeSessionsForDate(
   const closedSessions: DaySession[] = [];
 
   for (const session of sessions) {
-    if (!session.end && session.date !== today) {
+    if (!session.end && session.date < today) {
       const closed = autoCloseStaleSession(session, now);
       sanitizedSessions.push(closed);
       closedSessions.push(closed);


### PR DESCRIPTION
## Summary
- update sanitizeSessionsForDate to only close sessions dated before today
- add a regression test ensuring future-dated sessions remain open when starting a new day

## Testing
- npx vitest run src/useAppState.sessions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d27356810483328ced9a90e0d1dc43