### PR TITLE
Normalize list version from stored state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import "./App.css"; // Use the updated modern CSS
 import { ImportExcel } from "./ImportExcel";
 import { useAppState } from "./useAppState";
+import { normalizeState } from "./utils/normalizeState";
 import { useCloudSync } from "./useCloudSync";
 import { ModalProvider, useModalContext } from "./components/ModalProvider";
 import { logger } from "./utils/logger";
@@ -27,20 +28,6 @@ import { LocalBackupManager } from "./utils/localBackup";
 import { SettingsDropdown } from "./components/SettingsDropdown";
 
 type Tab = "list" | "completed" | "arrangements" | "earnings" | "planning";
-
-function normalizeState(raw: any) {
-  const r = raw ?? {};
-  return {
-    ...r,
-    addresses: Array.isArray(r.addresses) ? r.addresses : [],
-    completions: Array.isArray(r.completions) ? r.completions : [],
-    arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
-    daySessions: Array.isArray(r.daySessions) ? r.daySessions : [],
-    activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,
-    currentListVersion:
-      typeof r.currentListVersion === "number" ? r.currentListVersion : 1,
-  };
-}
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },

--- a/src/currentListVersion.test.ts
+++ b/src/currentListVersion.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeState } from "./utils/normalizeState";
+import type { AppState } from "./types";
+
+describe("list version normalization", () => {
+  function computeHiddenIndices(state: AppState): Set<number> {
+    const completions = Array.isArray(state.completions) ? state.completions : [];
+    const hidden = new Set<number>();
+
+    for (const completion of completions) {
+      const listVersion =
+        typeof completion?.listVersion === "number"
+          ? completion.listVersion
+          : state.currentListVersion;
+
+      if (listVersion === state.currentListVersion) {
+        hidden.add(Number(completion.index));
+      }
+    }
+
+    return hidden;
+  }
+
+  it("keeps current completions hidden when restoring a string list version", () => {
+    const rawState = {
+      addresses: [
+        { address: "1 Test Street" },
+        { address: "2 Example Road" },
+      ],
+      completions: [
+        {
+          index: 0,
+          address: "1 Test Street",
+          outcome: "Done",
+          timestamp: "2024-02-01T10:00:00.000Z",
+          listVersion: 2,
+        },
+        {
+          index: 1,
+          address: "2 Example Road",
+          outcome: "Done",
+          timestamp: "2024-01-30T17:00:00.000Z",
+          listVersion: 1,
+        },
+      ],
+      currentListVersion: "2",
+    } as const;
+
+    const normalized = normalizeState(rawState);
+
+    expect(normalized.currentListVersion).toBe(2);
+    expect(typeof normalized.currentListVersion).toBe("number");
+
+    const hidden = computeHiddenIndices(normalized as AppState);
+
+    expect(hidden.has(0)).toBe(true);
+    expect(hidden.has(1)).toBe(false);
+  });
+});

--- a/src/useCloudSync.ts
+++ b/src/useCloudSync.ts
@@ -5,6 +5,7 @@ import type { User } from "@supabase/supabase-js";
 import { supabase } from "./lib/supabaseClient";
 import type { AppState } from "./types";
 import { generateChecksum } from "./utils/checksum";
+import { coerceListVersion } from "./useAppState";
 
 // Initialize a new user with default subscription
 async function initializeNewUser(userId: string): Promise<void> {
@@ -95,14 +96,8 @@ export function mergeStatePreservingActiveIndex(
   current: AppState,
   incoming: AppState
 ): AppState {
-  const currentListVersion =
-    typeof current.currentListVersion === "number"
-      ? current.currentListVersion
-      : 1;
-  const incomingListVersion =
-    typeof incoming.currentListVersion === "number"
-      ? incoming.currentListVersion
-      : 1;
+  const currentListVersion = coerceListVersion(current.currentListVersion);
+  const incomingListVersion = coerceListVersion(incoming.currentListVersion);
 
   const ensureListVersion = (listVersion?: number) =>
     typeof listVersion === "number"
@@ -822,7 +817,10 @@ export function useCloudSync(): UseCloudSync {
     // For addresses, prefer the longer list (assume it's more complete)
     if (serverState.addresses.length > localState.addresses.length) {
       resolved.addresses = serverState.addresses;
-      resolved.currentListVersion = Math.max(localState.currentListVersion, serverState.currentListVersion);
+      resolved.currentListVersion = Math.max(
+        coerceListVersion(localState.currentListVersion),
+        coerceListVersion(serverState.currentListVersion)
+      );
     }
 
     resolved.activeIndex =

--- a/src/utils/normalizeState.ts
+++ b/src/utils/normalizeState.ts
@@ -1,0 +1,16 @@
+import { coerceListVersion } from "../useAppState";
+
+export function normalizeState(raw: any) {
+  const r = raw ?? {};
+  const currentListVersion = coerceListVersion(r.currentListVersion);
+
+  return {
+    ...r,
+    addresses: Array.isArray(r.addresses) ? r.addresses : [],
+    completions: Array.isArray(r.completions) ? r.completions : [],
+    arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
+    daySessions: Array.isArray(r.daySessions) ? r.daySessions : [],
+    activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,
+    currentListVersion,
+  };
+}


### PR DESCRIPTION
## Summary
- coerce stored list version values to numbers when normalizing state and restoring data from IndexedDB or cloud sync
- reuse a shared normalizer so optimistic updates and address imports always increment numeric versions
- add a regression test that ensures completions stay hidden after restoring a string list version snapshot

## Testing
- npx vitest run src/currentListVersion.test.ts src/useAppState.sessions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d27923d0e88332a19efbc19a0d57b0