### PR TITLE
Preserve local addresses when empty snapshot arrives

### DIFF
--- a/src/useCloudSync.test.ts
+++ b/src/useCloudSync.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { AppState } from "./types";
+import { mergeStatePreservingActiveIndex } from "./useCloudSync";
+
+const createState = (overrides: Partial<AppState>): AppState => ({
+  addresses: [],
+  activeIndex: null,
+  completions: [],
+  daySessions: [],
+  arrangements: [],
+  currentListVersion: 1,
+  ...overrides,
+});
+
+describe("mergeStatePreservingActiveIndex", () => {
+  it("keeps local addresses when incoming snapshot is newer but empty", () => {
+    const localState = createState({
+      addresses: [
+        { address: "123 Test Street" },
+        { address: "456 Another Ave" },
+      ],
+      currentListVersion: 1,
+    });
+
+    const incomingState = createState({
+      addresses: [],
+      currentListVersion: 2,
+    });
+
+    const merged = mergeStatePreservingActiveIndex(localState, incomingState);
+
+    expect(merged.addresses).toEqual(localState.addresses);
+  });
+
+  it("prefers incoming addresses when they contain data", () => {
+    const localState = createState({
+      addresses: [{ address: "123 Test Street" }],
+      currentListVersion: 1,
+    });
+
+    const incomingState = createState({
+      addresses: [
+        { address: "789 New Road" },
+        { address: "1011 Updated Way" },
+      ],
+      currentListVersion: 2,
+    });
+
+    const merged = mergeStatePreservingActiveIndex(localState, incomingState);
+
+    expect(merged.addresses).toEqual(incomingState.addresses);
+  });
+});

--- a/src/useCloudSync.ts
+++ b/src/useCloudSync.ts
@@ -163,11 +163,26 @@ export function mergeStatePreservingActiveIndex(
       ? incoming.addresses
       : [];
 
-    // Respect list versions - prefer higher version regardless of length
+    const hasMeaningfulData = (addresses: AppState['addresses']) =>
+      addresses.some(
+        (entry) => typeof entry?.address === 'string' && entry.address.trim().length > 0
+      );
+
+    const incomingHasData = hasMeaningfulData(incomingAddresses);
+    const currentHasData = hasMeaningfulData(currentAddresses);
+
+    // Respect list versions - prefer higher version only when it carries meaningful data
     if (incomingListVersion > currentListVersion) {
-      return incomingAddresses;
+      if (!incomingHasData && currentHasData) {
+        return currentAddresses;
+      }
+      return incomingHasData ? incomingAddresses : currentAddresses;
     } else if (currentListVersion > incomingListVersion) {
       return currentAddresses;
+    }
+
+    if (incomingHasData && !currentHasData) {
+      return incomingAddresses;
     }
 
     // Same version - use length as tiebreaker


### PR DESCRIPTION
## Summary
- prevent mergeStatePreservingActiveIndex from replacing populated addresses with empty snapshots
- add unit tests covering address selection when versions differ

## Testing
- npx vitest run src/useCloudSync.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d28ec49c188332b706b3e4d6e3ae46