### PR TITLE
Handle empty higher-version address snapshots

### DIFF
--- a/src/useCloudSync.test.ts
+++ b/src/useCloudSync.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { mergeStatePreservingActiveIndex } from "./useCloudSync";
+import type { AppState } from "./types";
+
+const createState = (overrides: Partial<AppState>): AppState => ({
+  addresses: [],
+  activeIndex: null,
+  completions: [],
+  daySessions: [],
+  arrangements: [],
+  currentListVersion: 1,
+  ...overrides,
+});
+
+describe("mergeStatePreservingActiveIndex", () => {
+  it("adopts incoming addresses when a higher version snapshot initially lacked data", () => {
+    const localState = createState({
+      addresses: [
+        { address: "123 Main St" },
+        { address: "456 Oak St" },
+      ],
+      currentListVersion: 1,
+    });
+
+    const higherVersionWithoutAddresses = createState({
+      addresses: [],
+      currentListVersion: 2,
+    });
+
+    const afterEmptyMerge = mergeStatePreservingActiveIndex(
+      localState,
+      higherVersionWithoutAddresses
+    );
+
+    expect(afterEmptyMerge.addresses).toEqual(localState.addresses);
+    expect(afterEmptyMerge.currentListVersion).toBe(localState.currentListVersion);
+
+    const populatedSameVersionSnapshot = createState({
+      addresses: [{ address: "789 Pine St" }],
+      currentListVersion: 2,
+    });
+
+    const afterPopulatedMerge = mergeStatePreservingActiveIndex(
+      afterEmptyMerge,
+      populatedSameVersionSnapshot
+    );
+
+    expect(afterPopulatedMerge.addresses).toEqual(
+      populatedSameVersionSnapshot.addresses
+    );
+    expect(afterPopulatedMerge.currentListVersion).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent `mergeStatePreservingActiveIndex` from upgrading the local list version when a higher-version snapshot lacks meaningful addresses
- prefer incoming addresses only when they contain real data or the versions match and they win the length tiebreaker
- add a regression test covering the empty higher-version snapshot followed by a populated same-version snapshot

## Testing
- `npx vitest run` *(fails: `ReferenceError: Deno is not defined` in `supabase/functions/search-addresses/utils.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68d2964b444c83329259b11f8b8e13fc