### PR TITLE
Normalize completion list versions across sync paths

### DIFF
--- a/src/currentListVersion.test.ts
+++ b/src/currentListVersion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { normalizeState } from "./utils/normalizeState";
+import { mergeStatePreservingActiveIndex } from "./useCloudSync";
 import type { AppState } from "./types";
 
 describe("list version normalization", () => {
@@ -56,5 +57,81 @@ describe("list version normalization", () => {
 
     expect(hidden.has(0)).toBe(true);
     expect(hidden.has(1)).toBe(false);
+  });
+
+  it("preserves numeric list versions for historical completions when normalizing", () => {
+    const rawState = {
+      addresses: [{ address: "1 Test Street" }],
+      completions: [
+        {
+          index: 0,
+          address: "1 Test Street",
+          outcome: "Done",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          listVersion: "3",
+        },
+      ],
+      currentListVersion: "5",
+    } as const;
+
+    const normalized = normalizeState(rawState) as AppState;
+
+    expect(normalized.currentListVersion).toBe(5);
+    expect(normalized.completions[0]?.listVersion).toBe(3);
+    expect(typeof normalized.completions[0]?.listVersion).toBe("number");
+  });
+
+  it("merges multi-device state without promoting older completion versions", () => {
+    const baseState = normalizeState({
+      addresses: [{ address: "1" }],
+      completions: [
+        {
+          index: 0,
+          address: "1",
+          outcome: "Done",
+          timestamp: "2024-02-01T10:00:00.000Z",
+          listVersion: 5,
+        },
+        {
+          index: 1,
+          address: "2",
+          outcome: "Done",
+          timestamp: "2024-01-10T12:00:00.000Z",
+          listVersion: 4,
+        },
+      ],
+      currentListVersion: 5,
+    }) as AppState;
+
+    const incomingState = normalizeState({
+      addresses: [{ address: "1" }],
+      completions: [
+        {
+          index: 2,
+          address: "3",
+          outcome: "Done",
+          timestamp: "2024-02-02T08:00:00.000Z",
+          listVersion: "5",
+        },
+        {
+          index: 3,
+          address: "4",
+          outcome: "Done",
+          timestamp: "2024-01-05T08:00:00.000Z",
+          listVersion: "3",
+        },
+      ],
+      currentListVersion: "5",
+    }) as AppState;
+
+    const merged = mergeStatePreservingActiveIndex(baseState, incomingState);
+
+    const versions = merged.completions.map((c) => c.listVersion);
+
+    expect(merged.currentListVersion).toBe(5);
+    expect(versions).toContain(5);
+    expect(versions).toContain(4);
+    expect(versions).toContain(3);
+    expect(versions.every((v) => typeof v === "number")).toBe(true);
   });
 });

--- a/src/useCloudSync.ts
+++ b/src/useCloudSync.ts
@@ -98,11 +98,14 @@ export function mergeStatePreservingActiveIndex(
 ): AppState {
   const currentListVersion = coerceListVersion(current.currentListVersion);
   const incomingListVersion = coerceListVersion(incoming.currentListVersion);
+  const fallbackListVersion = Math.max(
+    currentListVersion,
+    incomingListVersion,
+    1
+  );
 
-  const ensureListVersion = (listVersion?: number) =>
-    typeof listVersion === "number"
-      ? listVersion
-      : Math.max(currentListVersion, incomingListVersion);
+  const ensureListVersion = (listVersion?: number | string) =>
+    coerceListVersion(listVersion, fallbackListVersion);
 
   const mergedCompletionMap = new Map<string, AppState["completions"][number]>();
   const pushCompletion = (
@@ -852,11 +855,26 @@ export function useCloudSync(): UseCloudSync {
       }
     }
 
+    const localListVersion = coerceListVersion(localState.currentListVersion);
+    const serverListVersion = coerceListVersion(serverState.currentListVersion);
+    const fallbackListVersion = Math.max(
+      localListVersion,
+      serverListVersion,
+      1
+    );
+
     const resolved: AppState = { ...localState };
 
     // Merge completions (keep both, dedupe by timestamp + index + outcome)
     // This is the most critical data - completions represent work done
-    const allCompletions = [...localState.completions, ...serverState.completions];
+    const allCompletions = [...localState.completions, ...serverState.completions]
+      .map((completion) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          (completion as any)?.listVersion,
+          fallbackListVersion
+        ),
+      }));
     const uniqueCompletions = allCompletions.filter((completion, index, arr) => {
       // More comprehensive deduplication key including list version
       const key = `${completion.timestamp}_${completion.index}_${completion.outcome}_${completion.listVersion || 1}`;
@@ -864,9 +882,18 @@ export function useCloudSync(): UseCloudSync {
         `${c.timestamp}_${c.index}_${c.outcome}_${c.listVersion || 1}` === key
       ) === index;
     });
-    resolved.completions = uniqueCompletions.sort((a, b) =>
-      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-    );
+    resolved.completions = uniqueCompletions
+      .map((completion) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          (completion as any)?.listVersion,
+          fallbackListVersion
+        ),
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      );
 
     console.log(`Merged completions: local=${localState.completions.length}, server=${serverState.completions.length}, resolved=${resolved.completions.length}`);
 

--- a/src/utils/normalizeState.ts
+++ b/src/utils/normalizeState.ts
@@ -3,11 +3,20 @@ import { coerceListVersion } from "../useAppState";
 export function normalizeState(raw: any) {
   const r = raw ?? {};
   const currentListVersion = coerceListVersion(r.currentListVersion);
+  const completions = Array.isArray(r.completions)
+    ? r.completions.map((completion: any) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          completion?.listVersion,
+          currentListVersion
+        ),
+      }))
+    : [];
 
   return {
     ...r,
     addresses: Array.isArray(r.addresses) ? r.addresses : [],
-    completions: Array.isArray(r.completions) ? r.completions : [],
+    completions,
     arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
     daySessions: Array.isArray(r.daySessions) ? r.daySessions : [],
     activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,
@@ -18,9 +27,19 @@ export function normalizeState(raw: any) {
 // ARCHITECTURAL: Separate data from session state for backups
 export function normalizeBackupData(raw: any) {
   const r = raw ?? {};
+  const currentListVersion = coerceListVersion(r.currentListVersion);
+  const completions = Array.isArray(r.completions)
+    ? r.completions.map((completion: any) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          completion?.listVersion,
+          currentListVersion
+        ),
+      }))
+    : [];
   return {
     addresses: Array.isArray(r.addresses) ? r.addresses : [],
-    completions: Array.isArray(r.completions) ? r.completions : [],
+    completions,
     arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
     // NOTE: daySessions deliberately excluded from backups - they're temporal state
     activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,


### PR DESCRIPTION
## Summary
- coerce completion list versions when hydrating local state so legacy string values stay numeric
- ensure cloud merge and conflict resolution paths normalize list versions instead of promoting older completions to the current list
- cover normalization and multi-device merge behavior with vitest checks

## Testing
- npx vitest run currentListVersion.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4ecc456548332b2add56e21cef08a