### PR TITLE
Fix day panel edit action buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -425,6 +425,7 @@ body {
   height: 200%;
   background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
   animation: rotate 30s linear infinite;
+  pointer-events: none;
 }
 
 @keyframes rotate {
@@ -632,6 +633,8 @@ body {
   align-items: center;
   gap: 1rem;
   flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
 }
 
 .primary-actions {


### PR DESCRIPTION
## Summary
- prevent the decorative day panel overlay from intercepting clicks by disabling pointer events
- raise the action bar above the background layer so the edit buttons remain interactive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f76681848332a0423e40beac9dc4