### PR TITLE
Add completion ledger to resolve cross-device race conditions

### DIFF
--- a/src/currentListVersion.test.ts
+++ b/src/currentListVersion.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { normalizeState } from "./utils/normalizeState";
-import type { AppState } from "./types";
+import { mergeStatePreservingActiveIndex } from "./useCloudSync";
+import { applyCompletionLedger } from "./useAppState";
+import type { AppState, CompletionLedgerEntry } from "./types";
 
 describe("list version normalization", () => {
   function computeHiddenIndices(state: AppState): Set<number> {
@@ -56,5 +58,227 @@ describe("list version normalization", () => {
 
     expect(hidden.has(0)).toBe(true);
     expect(hidden.has(1)).toBe(false);
+  });
+
+  it("preserves numeric list versions for historical completions when normalizing", () => {
+    const rawState = {
+      addresses: [{ address: "1 Test Street" }],
+      completions: [
+        {
+          index: 0,
+          address: "1 Test Street",
+          outcome: "Done",
+          timestamp: "2024-01-01T00:00:00.000Z",
+          listVersion: "3",
+        },
+      ],
+      currentListVersion: "5",
+    } as const;
+
+    const normalized = normalizeState(rawState) as AppState;
+
+    expect(normalized.currentListVersion).toBe(5);
+    expect(normalized.completions[0]?.listVersion).toBe(3);
+    expect(typeof normalized.completions[0]?.listVersion).toBe("number");
+  });
+
+  it("merges multi-device state without promoting older completion versions", () => {
+    const baseState = normalizeState({
+      addresses: [{ address: "1" }],
+      completions: [
+        {
+          index: 0,
+          address: "1",
+          outcome: "Done",
+          timestamp: "2024-02-01T10:00:00.000Z",
+          listVersion: 5,
+        },
+        {
+          index: 1,
+          address: "2",
+          outcome: "Done",
+          timestamp: "2024-01-10T12:00:00.000Z",
+          listVersion: 4,
+        },
+      ],
+      currentListVersion: 5,
+    }) as AppState;
+
+    const incomingState = normalizeState({
+      addresses: [{ address: "1" }],
+      completions: [
+        {
+          index: 2,
+          address: "3",
+          outcome: "Done",
+          timestamp: "2024-02-02T08:00:00.000Z",
+          listVersion: "5",
+        },
+        {
+          index: 3,
+          address: "4",
+          outcome: "Done",
+          timestamp: "2024-01-05T08:00:00.000Z",
+          listVersion: "3",
+        },
+      ],
+      currentListVersion: "5",
+    }) as AppState;
+
+    const merged = mergeStatePreservingActiveIndex(baseState, incomingState);
+
+    const versions = merged.completions.map((c) => c.listVersion);
+
+    expect(merged.currentListVersion).toBe(5);
+    expect(versions).toContain(5);
+    expect(versions).toContain(4);
+    expect(versions).toContain(3);
+    expect(versions.every((v) => typeof v === "number")).toBe(true);
+  });
+
+  it("never downgrades the active list version when merging older cloud state", () => {
+    const baseState = normalizeState({
+      addresses: [
+        { address: "1" },
+        { address: "2" },
+      ],
+      completions: [
+        {
+          index: 0,
+          address: "1",
+          outcome: "Done",
+          timestamp: "2024-02-01T10:00:00.000Z",
+          listVersion: 4,
+        },
+      ],
+      currentListVersion: 4,
+    }) as AppState;
+
+    const incomingState = normalizeState({
+      addresses: [
+        { address: "1" },
+        { address: "2" },
+      ],
+      completions: [],
+      currentListVersion: 2,
+    }) as AppState;
+
+    const merged = mergeStatePreservingActiveIndex(baseState, incomingState);
+
+    expect(merged.currentListVersion).toBe(4);
+    expect(
+      merged.completions.every((completion) => completion.listVersion === 4)
+    ).toBe(true);
+  });
+
+  it("prefers the newest completion event for the same address across devices", () => {
+    const listVersion = 6;
+    const baseCompletion = {
+      index: 0,
+      address: "1 High Street",
+      outcome: "Done" as const,
+      timestamp: "2024-03-10T08:07:21.000Z",
+      listVersion,
+    };
+
+    const freshLedger: CompletionLedgerEntry = {
+      index: 0,
+      listVersion,
+      status: "completed",
+      eventTimestamp: baseCompletion.timestamp,
+      completion: baseCompletion,
+    };
+
+    const baseState = applyCompletionLedger({
+      addresses: [{ address: "1 High Street" }],
+      completions: [baseCompletion],
+      completionLedger: [freshLedger],
+      arrangements: [],
+      daySessions: [],
+      activeIndex: null,
+      currentListVersion: listVersion,
+    } as AppState);
+
+    const staleCompletion = {
+      ...baseCompletion,
+      timestamp: "2024-03-10T08:05:00.000Z",
+    };
+
+    const staleLedger: CompletionLedgerEntry = {
+      index: 0,
+      listVersion,
+      status: "completed",
+      eventTimestamp: staleCompletion.timestamp,
+      completion: staleCompletion,
+    };
+
+    const incomingState = applyCompletionLedger({
+      addresses: [{ address: "1 High Street" }],
+      completions: [staleCompletion],
+      completionLedger: [staleLedger],
+      arrangements: [],
+      daySessions: [],
+      activeIndex: null,
+      currentListVersion: listVersion,
+    } as AppState);
+
+    const merged = mergeStatePreservingActiveIndex(baseState, incomingState);
+
+    expect(merged.completions).toHaveLength(1);
+    expect(merged.completions[0]?.timestamp).toBe(baseCompletion.timestamp);
+  });
+
+  it("honors a newer undo event even if another device still has the completion", () => {
+    const listVersion = 7;
+    const completion = {
+      index: 1,
+      address: "2 Oak Lane",
+      outcome: "Done" as const,
+      timestamp: "2024-03-11T09:00:00.000Z",
+      listVersion,
+    };
+
+    const completionLedgerEntry: CompletionLedgerEntry = {
+      index: 1,
+      listVersion,
+      status: "completed",
+      eventTimestamp: completion.timestamp,
+      completion,
+    };
+
+    const baseState = applyCompletionLedger({
+      addresses: [{ address: "2 Oak Lane" }],
+      completions: [completion],
+      completionLedger: [completionLedgerEntry],
+      arrangements: [],
+      daySessions: [],
+      activeIndex: null,
+      currentListVersion: listVersion,
+    } as AppState);
+
+    const undoLedgerEntry: CompletionLedgerEntry = {
+      index: 1,
+      listVersion,
+      status: "undone",
+      eventTimestamp: "2024-03-11T09:05:00.000Z",
+      completion,
+    };
+
+    const incomingState = applyCompletionLedger({
+      addresses: [{ address: "2 Oak Lane" }],
+      completions: [completion],
+      completionLedger: [undoLedgerEntry],
+      arrangements: [],
+      daySessions: [],
+      activeIndex: null,
+      currentListVersion: listVersion,
+    } as AppState);
+
+    const merged = mergeStatePreservingActiveIndex(baseState, incomingState);
+
+    expect(merged.completions).toHaveLength(0);
+    expect(merged.completionLedger?.find((entry) => entry.index === 1)?.status).toBe(
+      "undone"
+    );
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,18 @@ export type Completion = {
   arrangementId?: string;
 };
 
+export type CompletionLedgerStatus = "completed" | "undone";
+
+export type CompletionLedgerEntry = {
+  index: number;
+  listVersion: number;
+  /** When this status change occurred. */
+  eventTimestamp: string;
+  status: CompletionLedgerStatus;
+  /** Completion payload when status === "completed". */
+  completion?: Completion;
+};
+
 export type DaySession = {
   date: string;             // "YYYY-MM-DD"
   start: string;            // ISO string
@@ -178,6 +190,8 @@ export type AppState = {
   addresses: AddressRow[];
   activeIndex: number | null;
   completions: Completion[];
+  /** Deterministic completion ledger used for conflict resolution across devices. */
+  completionLedger?: CompletionLedgerEntry[];
   daySessions: DaySession[];
   arrangements: Arrangement[];
   /** Increments whenever you import a new Excel list. */

--- a/src/utils/normalizeState.ts
+++ b/src/utils/normalizeState.ts
@@ -3,11 +3,23 @@ import { coerceListVersion } from "../useAppState";
 export function normalizeState(raw: any) {
   const r = raw ?? {};
   const currentListVersion = coerceListVersion(r.currentListVersion);
+  const completions = Array.isArray(r.completions)
+    ? r.completions.map((completion: any) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          completion?.listVersion,
+          currentListVersion
+        ),
+      }))
+    : [];
 
   return {
     ...r,
     addresses: Array.isArray(r.addresses) ? r.addresses : [],
-    completions: Array.isArray(r.completions) ? r.completions : [],
+    completions,
+    completionLedger: Array.isArray(r.completionLedger)
+      ? r.completionLedger
+      : undefined,
     arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
     daySessions: Array.isArray(r.daySessions) ? r.daySessions : [],
     activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,
@@ -18,9 +30,22 @@ export function normalizeState(raw: any) {
 // ARCHITECTURAL: Separate data from session state for backups
 export function normalizeBackupData(raw: any) {
   const r = raw ?? {};
+  const currentListVersion = coerceListVersion(r.currentListVersion);
+  const completions = Array.isArray(r.completions)
+    ? r.completions.map((completion: any) => ({
+        ...completion,
+        listVersion: coerceListVersion(
+          completion?.listVersion,
+          currentListVersion
+        ),
+      }))
+    : [];
   return {
     addresses: Array.isArray(r.addresses) ? r.addresses : [],
-    completions: Array.isArray(r.completions) ? r.completions : [],
+    completions,
+    completionLedger: Array.isArray(r.completionLedger)
+      ? r.completionLedger
+      : undefined,
     arrangements: Array.isArray(r.arrangements) ? r.arrangements : [],
     // NOTE: daySessions deliberately excluded from backups - they're temporal state
     activeIndex: typeof r.activeIndex === "number" ? r.activeIndex : null,


### PR DESCRIPTION
## Summary
- track completion status changes in a dedicated ledger so the newest event per address wins during hydration and sync
- reconcile app state against the ledger on load, import, restore, and cloud merges to prevent stale devices from reviving completed items
- merge completion ledger histories across devices and add regression tests covering newer completion and undo events

## Testing
- npx vitest run currentListVersion.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4ecc456548332b2add56e21cef08a