### PR TITLE
fix: resolve day session persistence bug and add elapsed timer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -659,6 +659,22 @@ body {
   border: 1px solid var(--gray-200);
 }
 
+/* Elapsed Timer */
+.elapsed-timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: var(--success);
+  font-variant-numeric: tabular-nums;
+  animation: pulse-subtle 2s ease-in-out infinite;
+}
+
+@keyframes pulse-subtle {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.85; }
+}
+
 .btn-modern {
   display: flex;
   align-items: center;

--- a/src/DayPanel.tsx
+++ b/src/DayPanel.tsx
@@ -8,6 +8,38 @@ import { LoadingSpinner } from "./components/LoadingButton";
 
 import { logger } from './utils/logger';
 
+// ElapsedTimer component - shows live elapsed time
+function ElapsedTimer({ startISO }: { startISO: string }) {
+  const [elapsed, setElapsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const updateElapsed = () => {
+      const start = new Date(startISO).getTime();
+      const now = Date.now();
+      const seconds = Math.floor((now - start) / 1000);
+      setElapsed(seconds);
+    };
+
+    // Update immediately
+    updateElapsed();
+
+    // Update every second
+    const interval = setInterval(updateElapsed, 1000);
+
+    return () => clearInterval(interval);
+  }, [startISO]);
+
+  const hours = Math.floor(elapsed / 3600);
+  const minutes = Math.floor((elapsed % 3600) / 60);
+  const seconds = elapsed % 60;
+
+  return (
+    <span className="elapsed-timer">
+      ⏱️ {hours}h {minutes.toString().padStart(2, '0')}m {seconds.toString().padStart(2, '0')}s
+    </span>
+  );
+}
+
 type Props = {
   sessions: DaySession[];
   completions: Completion[];
@@ -205,8 +237,8 @@ const DayPanelComponent = function DayPanel({
                   {latestToday?.end && (
                     <> → {fmtTime(latestToday.end)}</>
                   )}
-                  {isActive && !latestToday?.end && (
-                    <> • <span style={{ color: 'var(--success)' }}>Active</span></>
+                  {isActive && !latestToday?.end && latestToday.start && (
+                    <> • <ElapsedTimer startISO={latestToday.start} /></>
                   )}
                 </>
               ) : (


### PR DESCRIPTION
CRITICAL FIXES:
1. Race condition in App.tsx:521-524 that blocked initial state load
   - Added isInitialLoadRef to distinguish bootstrap vs live updates
   - Initial bootstrap now bypasses protection flag check
   - Protection flags still enforced for live updates after app loads
   - Fixes: Day sessions disappearing after page refresh

2. Missing elapsed timer in DayPanel
   - Added ElapsedTimer component showing live countdown (HH:mm:ss)
   - Updates every second showing time since session start
   - Styled with subtle pulse animation

TECHNICAL DETAILS:
- Root cause: Operation log loaded faster than protection flags
- Operation log reconstructed state and notified App.tsx
- App.tsx checked protectionFlagsReadyRef (still false), returned early
- Result: Day session from operations never applied to UI state

- Solution: Allow first load to bypass protection check
- After first load, protection flags are enforced normally
- No impact on restore/import/active protection mechanisms

Files changed:
- src/App.tsx: Added isInitialLoadRef logic
- src/DayPanel.tsx: Added ElapsedTimer component
- src/App.css: Added elapsed-timer styling

Complies with: Clean Architecture, Event Sourcing, Protection Flags