### PR TITLE
fix: resolve session timer and address sync persistence bugs (project…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -510,7 +510,7 @@ function AuthedApp({ cloudSync }: { cloudSync: ReturnType<typeof useUnifiedSync>
   // Delta sync subscription - Bootstrap handled by operationSync.ts
   React.useEffect(() => {
     const user = cloudSync.user;
-    if (!user || loading) return;
+    if (!user) return; // 🔧 FIX: Remove 'loading' check - causes race condition where subscription never activates
 
     logger.info('🔄 DELTA SYNC: Setting up operation subscription for user:', user.id);
 
@@ -600,7 +600,7 @@ function AuthedApp({ cloudSync }: { cloudSync: ReturnType<typeof useUnifiedSync>
     return () => {
       if (cleanup) cleanup();
     };
-  }, [cloudSync.user, loading]);
+  }, [cloudSync.user]); // 🔧 FIX: Remove 'loading' dependency - subscription only needs user
 
   // REMOVED: Visibility change handler - was over-engineering after fixing React subscription bug
 


### PR DESCRIPTION
… branch)

CRITICAL BUG FIXES: Fixes two race conditions preventing data persistence across page refreshes.

Root Cause Analysis:

Bug #1: Day Session Timer Disappears After Refresh
- Symptom: User starts day, timer active, refreshes page → session lost
- Root Cause: Subscription effect in App.tsx had dependency on 'loading'
  * Effect: useEffect(() => {...}, [cloudSync.user, loading])
  * Check: if (!user || loading) return;
  * Race: loading completes before user ready → effect exits early
  * Result: subscribeToData never called → local operations ignored
- Fix: Remove 'loading' dependency - subscription only needs user

Bug #2: Addresses Don't Sync to Device B
- Symptom: Import 23 addresses on Device A → Device B shows 0 addresses
- Root Cause: Operations created, user refreshes before 2s batch timer
  * Flow: submitOperation → scheduleBatchSync (2s delay) → page refresh
  * Timer cancelled before upload → operations in IndexedDB but not cloud
  * AUTO-SYNC effect runs but operationLog.current not ready yet (race)
  * Effect deps: [user?.id, isOnline, isLoading]
  * Init deps: [user?.id, isOnline, supabase] (different!)
  * Result: AUTO-SYNC skips, operations never uploaded
- Fix: Trigger sync from bootstrap after operationLog initialized

Implementation:

1. App.tsx (lines 513, 603):
   - Removed 'loading' check from subscription effect condition
   - Removed 'loading' from effect dependencies
   - Subscription now activates immediately when user authenticates

2. operationSync.ts (lines 670-684):
   - Added unsynced operation check after bootstrap completes
   - Calls scheduleBatchSync via ref if unsynced operations found
   - Guarantees operationLog.current exists before sync attempt

3. operationSync.ts (lines 724, 781-783):
   - Created scheduleBatchSyncRef to allow cross-effect calls
   - Updated ref via useEffect when scheduleBatchSync changes
   - Enables bootstrap to trigger sync without dependency issues

Impact:
✅ Session timer persists across page refreshes
✅ Address imports sync immediately on next app load ✅ Multi-device sync reliability improved
✅ No more lost operations from interrupted batch timers

Testing:
- Scenario 1: Start day → refresh → session should persist
- Scenario 2: Import addresses → close app → open on device B → addresses appear