### PR TITLE
fix: fetch missing operations before advancing sync pointer (data loss)

### DIFF
--- a/src/sync/operationSync.ts
+++ b/src/sync/operationSync.ts
@@ -1073,16 +1073,78 @@ export function useOperationSync(): UseOperationSync {
               });
 
               // 🔧 CRITICAL FIX: If cloud has sequences beyond our lastSyncSequence,
-              // advance lastSyncSequence to cloudMaxSeq since those are already in cloud
-              // This fills the gap and allows the reassigned sequence to advance properly
+              // we must FETCH those operations before advancing the pointer
+              // Otherwise we permanently skip/lose operations from other devices
               const currentLastSynced = operationLog.current.getLogState().lastSyncSequence;
               if (cloudMaxSeq > currentLastSynced) {
-                await operationLog.current.markSyncedUpTo(cloudMaxSeq);
-                logger.info('🔧 ADVANCED SYNC POINTER: Filled gap from other devices', {
-                  oldLastSynced: currentLastSynced,
-                  newLastSynced: cloudMaxSeq,
-                  gapSize: cloudMaxSeq - currentLastSynced,
+                logger.info('🔄 FETCHING MISSING OPERATIONS before advancing sync pointer', {
+                  currentLastSynced,
+                  cloudMaxSeq,
+                  missingRange: `${currentLastSynced + 1}-${cloudMaxSeq}`,
                 });
+
+                try {
+                  // Fetch operations we've never seen (between our pointer and cloud max)
+                  const { data: missingOpsData, error: fetchError } = await currentSupabase!
+                    .from('navigator_operations')
+                    .select('operation_data, sequence_number')
+                    .eq('user_id', currentUser.id)
+                    .gt('sequence_number', currentLastSynced)
+                    .lte('sequence_number', cloudMaxSeq)
+                    .order('sequence_number', { ascending: true });
+
+                  if (fetchError) {
+                    logger.error('❌ Failed to fetch missing operations:', fetchError);
+                    throw new Error(`Failed to fetch missing operations: ${fetchError.message}`);
+                  }
+
+                  if (missingOpsData && missingOpsData.length > 0) {
+                    logger.info(`📥 FETCHED ${missingOpsData.length} missing operations from cloud`);
+
+                    const missingOperations: Operation[] = missingOpsData
+                      .map(row => {
+                        const op = { ...row.operation_data };
+                        // Use database sequence_number (source of truth)
+                        if (row.sequence_number && typeof row.sequence_number === 'number') {
+                          op.sequence = row.sequence_number;
+                        }
+                        return op;
+                      })
+                      .filter(op => op.id && op.type); // Validate
+
+                    // Merge into local log
+                    const merged = await operationLog.current.mergeRemoteOperations(missingOperations);
+                    logger.info(`✅ MERGED ${merged.length} new operations into local log`);
+
+                    // Rebuild state to apply the operations
+                    const newState = rebuildStateIfNeeded(true);
+                    setCurrentState(newState);
+
+                    // Notify listeners
+                    const allOps = operationLog.current.getAllOperations();
+                    stateChangeListeners.current.forEach(listener => {
+                      try {
+                        listener(allOps);
+                      } catch (err) {
+                        logger.error('Error in state change listener:', err);
+                      }
+                    });
+                  } else {
+                    logger.info('📭 No missing operations found (gap may be from deleted operations)');
+                  }
+
+                  // NOW it's safe to advance the sync pointer
+                  await operationLog.current.markSyncedUpTo(cloudMaxSeq);
+                  logger.info('🔧 ADVANCED SYNC POINTER after fetching missing operations', {
+                    oldLastSynced: currentLastSynced,
+                    newLastSynced: cloudMaxSeq,
+                    gapSize: cloudMaxSeq - currentLastSynced,
+                  });
+                } catch (fetchErr) {
+                  logger.error('❌ CRITICAL: Failed to fetch missing operations before advancing pointer:', fetchErr);
+                  // Don't advance pointer if we couldn't fetch - better to retry than lose data
+                  throw fetchErr;
+                }
               }
 
               // Update sequence generator to avoid future collisions


### PR DESCRIPTION
ROOT CAUSE (P1 - DATA LOSS):
When sequence collision repair advanced lastSyncSequence to cloudMaxSeq, it skipped fetching operations in that range, causing PERMANENT DATA LOSS.

Scenario:
1. Device A: lastSyncSequence = 101
2. Cloud has operations 102-200 (from Device B) - NOT YET FETCHED
3. Device A creates operation, gets sequence 102 → collision!
4. Old fix: Advance lastSyncSequence to 200 immediately ❌
5. Device A NEVER fetched operations 102-200
6. Next fetch: .gt('sequence_number', 200) → skips 102-200
7. Operations 102-200 PERMANENTLY LOST on Device A
8. Device A missing all of Device B's data in that range

Impact:
- Device B imports addresses → Device A never sees them
- Device B creates completions → Device A never sees them
- Silent data loss - no errors, just missing data
- Affects multi-device sync reliability

NEW FIX:
Before advancing lastSyncSequence, FETCH and MERGE missing operations:

1. Detect: cloudMaxSeq > currentLastSynced
2. Fetch: Operations between currentLastSynced and cloudMaxSeq
   - .gt('sequence_number', currentLastSynced)
   - .lte('sequence_number', cloudMaxSeq)
3. Merge: Add to local operation log
4. Apply: Rebuild state and notify listeners
5. Advance: NOW safe to markSyncedUpTo(cloudMaxSeq)

This ensures:
✅ No operations skipped/lost
✅ Complete operation history downloaded
✅ State fully reconstructed
✅ Multi-device sync works correctly

Error handling:
- If fetch fails, throw error and DON'T advance pointer
- Better to retry than lose data
- Logs show what range was fetched

Changes:
- src/sync/operationSync.ts (lines 1075-1148):
  - Fetch missing operations from cloud
  - Merge into local log
  - Rebuild state to apply operations
  - Notify listeners of state change
  - Only then advance sync pointer

Fixes: Permanent data loss, multi-device sync reliability