### PR TITLE
Fix timer persistence on page refresh

### DIFF
--- a/src/useAppState.ts
+++ b/src/useAppState.ts
@@ -545,6 +545,7 @@ export function useAppState(userId?: string, submitOperation?: SubmitOperationCa
           const next: AppState = {
             addresses: saved.addresses.filter(validateAddressRow),
             activeIndex: (typeof saved.activeIndex === "number") ? saved.activeIndex : null,
+            activeStartTime: saved.activeStartTime ?? null,
             completions: stampCompletionsWithVersion(saved.completions, version),
             daySessions: Array.isArray(saved.daySessions) ? saved.daySessions : [],
             arrangements: Array.isArray(saved.arrangements) ? saved.arrangements : [],
@@ -1578,6 +1579,7 @@ export function useAppState(userId?: string, submitOperation?: SubmitOperationCa
       addresses: baseState.addresses,
       completions: baseState.completions,
       activeIndex: baseState.activeIndex,
+      activeStartTime: baseState.activeStartTime,
       daySessions: baseState.daySessions,
       arrangements: baseState.arrangements,
       currentListVersion: baseState.currentListVersion,
@@ -1626,6 +1628,7 @@ export function useAppState(userId?: string, submitOperation?: SubmitOperationCa
         addresses: obj.addresses,
         completions: stampCompletionsWithVersion(obj.completions, version),
         activeIndex: obj.activeIndex ?? null,
+        activeStartTime: obj.activeStartTime ?? null,
         daySessions: obj.daySessions ?? [],
         arrangements: obj.arrangements ?? [],
         currentListVersion: version,
@@ -1705,6 +1708,7 @@ export function useAppState(userId?: string, submitOperation?: SubmitOperationCa
             ),
 
             activeIndex: restoredState.activeIndex ?? currentState.activeIndex,
+            activeStartTime: restoredState.activeStartTime ?? currentState.activeStartTime,
           };
 
           return merged;


### PR DESCRIPTION
**Root Cause**:
When state was loaded from IndexedDB after page refresh, the activeStartTime field was not being restored. This caused the day timer to disappear even though the session was still active in daySessions array.

**Changes**:
- Added activeStartTime restoration in state loading (line 548)
- Added activeStartTime to backup state snapshot (line 1582)
- Added activeStartTime to restore state (line 1630)
- Added activeStartTime to merge strategy (line 1710)

**Impact**:
✅ Day timer now persists across page refreshes
✅ Active day sessions remain visible after refresh ✅ Backup/restore operations preserve day timer state