### PR TITLE
fix: allow day timer to persist on page refresh by bypassing session …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -597,7 +597,10 @@ function AuthedApp({ cloudSync }: { cloudSync: ReturnType<typeof useUnifiedSync>
       if (isInitialLoad) {
         isInitialLoadRef.current = false; // Mark as handled
       }
-      if (isProtectionActive('navigator_session_protection')) {
+
+      // 🔧 CRITICAL FIX: Allow initial load (bootstrap) to bypass session protection
+      // Session protection should only block ongoing realtime updates, not initial state load
+      if (!isInitialLoad && isProtectionActive('navigator_session_protection')) {
         logger.sync('🛡️ APP: DAY SESSION PROTECTION - Skipping cloud state update');
         return;
       }


### PR DESCRIPTION
…protection on bootstrap

Root Cause:
When starting a day and refreshing within 60 seconds, the timer disappeared because the session protection flag blocked the initial bootstrap state load.

The flow was:
1. User starts day → session protection flag set (60s timeout)
2. User refreshes page → bootstrap fires to reconstruct state from operations
3. App.tsx line 600 checks session protection → returns early BEFORE considering isInitialLoad
4. Bootstrap blocked → day session not restored → timer disappears

The Fix:
Added `!isInitialLoad` check before session protection (App.tsx:603)

Before:
  if (isProtectionActive('navigator_session_protection')) {
    return; // Blocks bootstrap!
  }

After:
  if (!isInitialLoad && isProtectionActive('navigator_session_protection')) {
    return; // Allows bootstrap, blocks only ongoing updates
  }

Impact:
✅ Day timer persists across page refreshes
✅ Session protection still prevents race conditions during updates ✅ Bootstrap state loading works correctly

Testing:
1. Start day
2. Refresh page (even within 60s)
3. Timer should still be running